### PR TITLE
Submodule: Force git to use correct repos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ansible/irma-ansible"]
 	path = ansible/irma-ansible
-	url = git@github.com:quarkslab/irma-ansible.git
+	url = https://github.com/quarkslab/irma-ansible.git
   branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ansible/irma-ansible"]
 	path = ansible/irma-ansible
-	url = ../irma-ansible.git
+	url = git@github.com:quarkslab/irma-ansible.git
   branch = master

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,27 @@
+ssh pull of branch:  
+
+```
+git clone --recursive git@github.com:krisshol/bach-kmno.git -b submodule
+```
+
+or
+
+```
+git clone --recurse-submodules git@github.com:krisshol/bach-kmno.git -b submodule
+```
+
+https pull of branch:
+
+```
+git clone --recursive https://github.com/krisshol/bach-kmno.git -b submodule
+```
+
+or
+
+```
+git clone --recurse-submodules https://github.com/krisshol/bach-kmno.git -b submodule
+```
+
 IRMA: Incident Response & Malware Analysis
 ------------------------------------------
 

--- a/ansible/ansible-requirements.yml
+++ b/ansible/ansible-requirements.yml
@@ -27,3 +27,6 @@
 - src: https://github.com/willshersystems/ansible-sshd.git
   version: v0.4.7
   name: willshersystems.sshd
+
+- src: https://github.com/nikolaifa/yara.git
+  name: nikolaifa.yara

--- a/ansible/environments/dev_vmware.yml
+++ b/ansible/environments/dev_vmware.yml
@@ -49,7 +49,7 @@ servers:
     memory: 2048
     rabbitmq_os_package: true
     shares:
-      - share_from: ../brain
+      - share_from: ../probe
         share_to: /opt/irma/irma-probe/releases/sync
         share_exclude:
           - .git/

--- a/ansible/environments/dev_vmware.yml
+++ b/ansible/environments/dev_vmware.yml
@@ -42,7 +42,7 @@ servers:
           - venv/
   - name: avs-linux.irma
     ip: 172.16.1.32
-    ansible_groups: [trid, escan, fsecure, bitdefender, fprot, virustotal, static-analyzer]
+    ansible_groups: [trid, escan, fsecure, bitdefender, fprot, virustotal, static-analyzer, yara]
     #Ikke fungerende antivirus i egen dokumentasjon på google drive
     box: debian_vmware
     cpus: 2

--- a/ansible/environments/dev_vmware.yml
+++ b/ansible/environments/dev_vmware.yml
@@ -42,7 +42,7 @@ servers:
           - venv/
   - name: avs-linux.irma
     ip: 172.16.1.32
-    ansible_groups: [trid, escan, fsecure, bitdefender, fprot, virustotal, static-analyzer, yara]
+    ansible_groups: [trid, escan, fsecure, bitdefender, fprot, virustotal, static-analyzer ]
     #Ikke fungerende antivirus i egen dokumentasjon på google drive
     box: debian_vmware
     cpus: 2

--- a/ansible/environments/dev_vmware.yml
+++ b/ansible/environments/dev_vmware.yml
@@ -50,7 +50,7 @@ servers:
     rabbitmq_os_package: true
     shares:
       - share_from: ../brain
-        share_to: /opt/irma/irma-brain/releases/sync
+        share_to: /opt/irma/irma-probe/releases/sync
         share_exclude:
           - .git/
           - venv/

--- a/ansible/playbooks/provisioning.yml
+++ b/ansible/playbooks/provisioning.yml
@@ -190,11 +190,16 @@
   become: yes
   roles:
     - { role: quarkslab.unarchiver, tags: unarchiver }
+
 - name: LIEF provisioning
   hosts: lief
   roles:
     - { role: quarkslab.lief, tags: lief }
 
+- name:
+  hosts: yara
+  roles:
+    - { role: nikolaifa.yara, tags: yara }
 - name: Dummy provisionning
   hosts: dummy
   roles:

--- a/ansible/playbooks/provisioning.yml
+++ b/ansible/playbooks/provisioning.yml
@@ -196,10 +196,11 @@
   roles:
     - { role: quarkslab.lief, tags: lief }
 
-- name:
+- name: Yara provisioning
   hosts: yara
   roles:
     - { role: nikolaifa.yara, tags: yara }
+
 - name: Dummy provisionning
   hosts: dummy
   roles:


### PR DESCRIPTION
The original .gitmodules setup does not work with forks of any kind. The fetching of the quarkslab/irma-ansible is necessary in one way or another, and this is one such way.